### PR TITLE
[Update manifest] microservice-a for new image tag 241f51d8ff3d2496b09e1066a5bc3856080c87dd

### DIFF
--- a/manifests/microservice-a/app.yaml
+++ b/manifests/microservice-a/app.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: microservice-a
       containers:
         - name: microservice-a
-          image: harbor.kncicd.tk/library/microservice-a:03e382cdedaecd6f607f3926642ad0da77e68331
+          image: registry-harbor-core.harbor.svc.cluster.local/library/microservice-a:241f51d8ff3d2496b09e1066a5bc3856080c87dd
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
RP is opened at 1599338293

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-cicd/commit/241f51d8ff3d2496b09e1066a5bc3856080c87dd

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-cicd/tree/241f51d8ff3d2496b09e1066a5bc3856080c87dd/microservices/microservice-a